### PR TITLE
handle multivalue/list SeriesDescriptions specifically 

### DIFF
--- a/common_utils.py
+++ b/common_utils.py
@@ -1,6 +1,8 @@
+import logging
 import re
 import ast
 
+log = logging.getLogger(__name__)
 
 # Scan Coverage
 def compute_scan_coverage(df):
@@ -14,10 +16,14 @@ def compute_scan_coverage(df):
 
 # Utility:  Check a list of regexes for truthyness
 def regex_search_label(regexes, label):
-    if any(regex.search(label) for regex in regexes):
-            return True
-    else:
-            return False
+    found = False
+    if type(label) == str:
+        if any(regex.search(label) for regex in regexes):
+            found = True
+    elif isinstance(label, list):
+        if any(regex_search_label(regexes, item) for item in label):
+            found = True
+    return found
 
         
 # Localizer

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,0 +1,32 @@
+import re
+import common_utils
+
+
+def test_regex_search_label():
+    test_regex_list = [re.compile('^[A-Za-z0-9]+$')]
+
+    # Test non-string
+    input_label = None
+    matches = common_utils.regex_search_label(test_regex_list, input_label)
+    assert matches is False
+
+    # Test match
+    input_label = 'R2D2'
+    matches = common_utils.regex_search_label(test_regex_list, input_label)
+    assert matches is True
+
+    # Test no match
+    input_label = 'C-3PO'
+    matches = common_utils.regex_search_label(test_regex_list, input_label)
+    assert matches is False
+
+    input_label = ['R2D2', 'C-3PO']
+    matches = common_utils.regex_search_label(test_regex_list, input_label)
+    assert matches is True
+
+
+def test_is_localizer():
+    input_label = 'LOCALIZER'
+    assert common_utils.is_localizer(input_label)
+    input_label = 2
+    assert not common_utils.is_localizer(input_label)


### PR DESCRIPTION
Adds more specificity to list SeriesDescriptions rather than outright failing to match (GEAR-255)
This release contains a patch to handle DICOM files that have SeriesDescriptions which are not string type. Previously an exception would be raised when a regex match was attempted on these non-string values. This patch returns False if the label is not a string or a list that contains at least one string that matches the input regexes.