### PR TITLE
Phcimg 1208 check other pet tracer locations

### DIFF
--- a/PT_classifier.py
+++ b/PT_classifier.py
@@ -58,7 +58,9 @@ TRACER_MEANINGS = {
     'Pittsburgh compound B C^11^': 'PiB',
     # then values found for Radiopharmaceutical
     #not sure if this can work, Radiopharmaceutical may be free-form text ?
-    'FDG -- fluorodeoxyglucose': 'FDG'
+    'FDG -- fluorodeoxyglucose': 'FDG',
+    'Fluorodeoxyglucose': 'FDG',
+    'HMDP': 'HMDP',
 }
 
 TRACER_TO_ISOTOPE = { # For some tracers, the tracer dictates the isotope
@@ -74,10 +76,12 @@ TRACER_TO_ISOTOPE = { # For some tracers, the tracer dictates the isotope
 ISOTOPE_CODES = {
     'C-111A1': 'F18',
     'C-105A1': 'C11',
-    'C-168A4': 'Zr89'
+    'C-168A4': 'Zr89',
+    'C-163A8': 'T99m'
 }
 ISOTOPE_MEANINGS = {
-    '^18^Fluorine': 'F18'
+    '^18^Fluorine': 'F18',
+    '99m Technetium': 'T99m'
 }
 
 

--- a/PT_classifier.py
+++ b/PT_classifier.py
@@ -287,8 +287,13 @@ class TracerPTSubClassifier(PTSubClassifier):
         if isotope and not classification['Isotope']:
             classification['Isotope'].append(isotope)
 
+        # check radiopharmaceutical locations, since it could vary by
+        # manufacturer
         radiopharma = self.get_dicom_tag(
             'RadiopharmaceuticalInformationSequence.0.RadionuclideCodeSequence.0.Radiopharmaceutical')
+        if radiopharma is None:
+            radiopharma = self.get_dicom_tag(
+                'RadiopharmaceuticalInformationSequence.0.Radiopharmaceutical')
 
         if radiopharma and radiopharma.lower() in lc_kw:
             tracer = lc_kw[code_meaning_tracer.lower()]


### PR DESCRIPTION
- added header check for radiopharma tracer
- Added 'Fluorodeoxyglucose' and 'HMDP' in 'TRACER_MEANINGS' dic; added 'T99m' in ISOTOPE_CODES and ISOTOPE_MEANINGS dics.